### PR TITLE
changed URLBASE

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -13,7 +13,7 @@ else
     exit;
 fi
 
-URLBASE="https://vscode-update.azurewebsites.net/latest/linux-${DIST}-x64/stable";
+URLBASE="https://update.code.visualstudio.com/latest/linux-${DIST}-x64/stable";
 FILENAME="$DIR/latest.${DIST}";
 
 if test -e "$FILENAME"; then


### PR DESCRIPTION
The previous url used in URLBASE stopped responding to wget, so according to https://vscode-update.azurewebsites.net/, the domain was replaced with https://update.code.visualstudio.com/.