### PR TITLE
added error-handling

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -23,9 +23,10 @@ fi
 
 echo "Downloading latest version of vscode is starting...";
 wget --show-progress -O $FILENAME $URLBASE;
-if [ $? -ne 0 ]; then
-    echo "Failed to download."
-    exit 1
+RESULT="$?";
+if ((RESULT != 0)); then
+    echo "Failed to download.";
+    exit 1;
 fi
 printf "Downloading finished.\n\n";
 

--- a/update.sh
+++ b/update.sh
@@ -23,6 +23,10 @@ fi
 
 echo "Downloading latest version of vscode is starting...";
 wget --show-progress -O $FILENAME $URLBASE;
+if [ $? -ne 0 ]; then
+    echo "Failed to download."
+    exit 1
+fi
 printf "Downloading finished.\n\n";
 
 echo "Closing vscode...";


### PR DESCRIPTION
There was no error handling for `wget` command and so, regardless of its exit status, the rest of the script would still run. Some lines were added to make sure the script exits when the download fails.