### PR TITLE
Check the base distro to support derivatives such as Mint. Use the distro's dependency resolver.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -11,13 +11,15 @@ if [ -f /etc/os-release ]; then
     # UBUNTU_CODENAME=jammy
     # ^ (if set at all, it is Ubuntu-based). However, the more standard variable is:
     # ID_LIKE="ubuntu debian"
-    for name in $ID_LIKE; do
-        if [ "$name" = "ubuntu" ]; then
-            DIST="deb";
-        elif [ "$name" = "debian" ]; then
-            DIST="deb";
-        fi
-    done
+    if [ ! -z "$ID_LIKE" ]; then
+        for name in $ID_LIKE; do
+            if [ "$name" = "ubuntu" ]; then
+                DIST="deb";
+            elif [ "$name" = "debian" ]; then
+                DIST="deb";
+            fi
+        done
+    fi
 fi
 
 if [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ]; then

--- a/update.sh
+++ b/update.sh
@@ -5,11 +5,26 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 DIST="";
 ARCH=$(uname -m);
 
+if [ -f /etc/os-release ]; then
+    source /etc/os-release
+    # ^ If not ubuntu but is Ubuntu-based, may contain:
+    # UBUNTU_CODENAME=jammy
+    # ^ (if set at all, it is Ubuntu-based). However, the more standard variable is:
+    # ID_LIKE="ubuntu debian"
+    for name in $ID_LIKE; do
+        if [ "$name" = "ubuntu" ]; then
+            DIST="deb";
+        elif [ "$name" = "debian" ]; then
+            DIST="deb";
+        fi
+    done
+fi
+
 if [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ]; then
     DIST="deb";
 elif [ "$OS" = "Fedora" ] || [ "$OS" = "Red Hat" ] || [ "$OS" = "Red hat" ]; then
     DIST="rpm";
-else
+elif [ -z "$DIST" ]; then
     echo "Unfortunately your operating system is not supported in distributed packages.";
     exit;
 fi

--- a/update.sh
+++ b/update.sh
@@ -47,8 +47,11 @@ echo "vscode instance(s) closed.";
 echo "Installing latest version...";
 if [ "$DIST" = "deb" ]; then
     sudo dpkg -i $FILENAME;
+    sudo apt-get update
+    sudo apt-get install -f -y  # -f: install dependencies
 else
-    sudo rpm -i $FILENAME;
+    # sudo rpm -i $FILENAME;
+    yum --nogpgcheck localinstall $FILENAME;  # Install and get dependencies
 fi
 echo "Installation finished.";
 

--- a/update.sh
+++ b/update.sh
@@ -66,7 +66,11 @@ if [ "$DIST" = "deb" ]; then
     sudo apt-get install -f -y  # -f: install dependencies
 else
     # sudo rpm -i $FILENAME;
-    yum --nogpgcheck localinstall $FILENAME;  # Install and get dependencies
+    dep_resolver="yum"
+    if [ -f "`command -v dnf`" ]; then
+        dep_resolver="dnf"
+    fi
+    $dep_resolver --nogpgcheck localinstall $FILENAME;  # Install and get dependencies
 fi
 echo "Installation finished.";
 

--- a/update.sh
+++ b/update.sh
@@ -2,6 +2,15 @@
 
 OS=$(lsb_release -si);
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
+TMP=/tmp
+
+if [ -w "$DIR" ]; then
+    echo "Downloading to $DIR";
+else
+    echo "$DIR not writable. Using $TMP";
+    DIR="$TMP";
+fi;
+
 DIST="";
 ARCH=$(uname -m);
 


### PR DESCRIPTION
- Support Linux Mint and other Debian or Ubuntu derivatives: Process `ID_LIKE` from /etc/os-release if present, in case the operating system is ubuntu or debian based (iterate it since there may be space-separated values if based on more than one)
- Gather dependencies automatically using the correct dependency resolver.